### PR TITLE
Improved Leaderboard Response Time

### DIFF
--- a/src/commands/leaderboard.ts
+++ b/src/commands/leaderboard.ts
@@ -4,150 +4,20 @@ import { colors, version } from '../config/config'
 import { currency } from '../utils/format'
 import { addCommandField } from '../utils/field'
 import { log } from '../utils/log'
+import { Leaderboard } from '../models/leaderboard.model'
 
+let desc = ''
 const helpInfo: any = {
     'leaderboard bet': '- Display the highest bets won.',
     'leaderboard streak': '- Display the highest daily streaks.',
     'leaderboard cash': '- Display the wealthiest users.',
-    'leaderboard coinflip': 'Display the luckiest users.'
+    'leaderboard coinflip': '- Display the luckiest users.'
 }
 
-let desc: string = ''
 const lbEmbed = new MessageEmbed()
     .setColor(colors.green)
     .setAuthor('Leaderboard')
     .setFooter(`LeCashBot v${version}`)
-
-const getTopTen = (arr: any[]) => arr.slice(-10).reverse()
-
-// The sort type is the property of users that the function sorts by
-const sortUsers = (users: any[], sortType: string) => {
-    return users.sort((a, b) => {
-        return (a[sortType] > b[sortType]) ? 1 : (
-            (b[sortType] > a[sortType]) ? -1 : 0
-        )
-    })
-}
-
-const handleFlipLb = (msg, users: any[]) => {
-    const sortedUsers = users.sort((a, b) => {
-        const aStreak: number = a.coinflipBestStreak
-        const bStreak: number = b.coinflipBestStreak
-        return (aStreak > bStreak) ? 1 : ((bStreak > aStreak) ? -1 : 0)
-    })
-    const topTen: any = getTopTen(sortedUsers)
-
-    let userPosition: any = 'You are not ranked!'
-    let userStreak: any = 'N/A'
-    let userEarnings: any = 'N/A'
-    let userStreakChance: any = 'N/A'
-    sortedUsers.reverse().forEach((user, index) => {
-        if (user.discordId === msg.author.id) {
-            userPosition = index + 1
-            userStreak = user.coinflipBestStreak
-            userStreakChance = Math.round((100 / (2 ** user.coinflipBestStreak)) * 100) / 100
-            return userEarnings = (user.coinflipBestStreak) 
-                ? Math.round((100 * (3 ** (user.coinflipBestStreak - 2))) + ((user.coinflipBestStreak - 1) * 150)) 
-                : 0
-        }
-    })
-
-    topTen.forEach(({ coinflipBestStreak, name }, pos) => {
-        const coinflipAmount: number = (coinflipBestStreak) ? Math.round((100 * (3 ** (coinflipBestStreak - 2))) + ((coinflipBestStreak - 1) * 150)) : 0
-        const coinflipChance: number = (coinflipBestStreak) ? Math.round((100 / (2 ** coinflipBestStreak)) * 100) / 100 : 0
-        desc += `#**${pos + 1}** ${name} - **${coinflipBestStreak}** - $**${currency(coinflipAmount)}** - ${coinflipChance}%\n`
-    })
-    desc += `#**${userPosition}** - YOU - **${currency(userStreak)}** - $**${currency(userEarnings)}** - ${userStreakChance}%`
-
-    lbEmbed.setDescription(desc)
-    desc = ''
-
-    return msg.channel.send(lbEmbed.setTimestamp(new Date()))
-}
-
-const handleBetLb = (msg, users: any[]) => {
-    const sortedUsers = users.sort((a, b) => {
-        const aBet: number = a.highestBet.amount
-        const bBet: number = b.highestBet.amount
-        return (aBet > bBet) ? 1 : ((bBet > aBet) ? -1 : 0)
-    })
-    const topTen: any = getTopTen(sortedUsers)
-
-    let userPosition: any = 'You are not ranked!'
-    let userBet: any = 'N/A'
-    let userBetChance: any = 'N/A'
-    sortedUsers.reverse().forEach((user, index) => {
-        if (user.discordId === msg.author.id) {
-            userPosition = index + 1
-            userBet = user.highestBet.amount
-            userBetChance = Math.round(user.highestBet.chance * 100) / 100
-        }
-    })
-
-    topTen.forEach(({ highestBet, name }, pos) => {
-        const betAmount: string = currency(highestBet.amount)
-        const betChance: number = Math.round(highestBet.chance * 100) / 100
-        desc += `#**${pos + 1}** ${name} - $**${betAmount}** - ${betChance}%\n`
-    })
-    desc += `#**${userPosition}** - YOU - $**${currency(userBet)}** - ${userBetChance}%`
-
-    lbEmbed.setDescription(desc)
-    desc = ''
-
-    return msg.channel.send(lbEmbed.setTimestamp(new Date()))
-}
-
-const handleCashLb = (msg, users) => {
-    const sortedUsers: any = sortUsers(users, 'balance')
-    const topTen: any = getTopTen(sortedUsers)
-
-    let userPosition: any = 'N/A'
-    let userBalance: any = 'N/A'
-    sortedUsers.reverse().forEach(({
-        discordId,
-        balance
-    }, index: number) => {
-        if (discordId === msg.author.id) {
-            userPosition = index + 1
-            userBalance = balance
-        }
-    })
-
-    topTen.forEach((user, pos: number) => {
-        desc += `#**${pos + 1}** ${user.name} - $**${currency(user.balance)}**\n`
-    })
-    desc += `#**${userPosition}** - YOU - $**${currency(userBalance)}**`
-    lbEmbed.setDescription(desc)
-    desc = ''
-
-    return msg.channel.send(lbEmbed.setTimestamp(new Date()))
-}
-
-const handleStreakLb = (msg, users) => {
-    const sortedUsers = sortUsers(users, 'dailyStreak')
-    const topTen = getTopTen(sortedUsers)
-
-    let userPosition: any = 'N/A'
-    let userStreak: any = 'N/A'
-    sortedUsers.reverse().forEach(({
-        discordId,
-        dailyStreak
-    }, index) => {
-        if (discordId === msg.author.id) {
-            userPosition = index + 1
-            userStreak = dailyStreak
-        }
-    })
-
-    topTen.forEach((user, pos) => {
-        desc += `#**${pos + 1}** ${user.name} - **${currency(user.dailyStreak)}**\n`
-    })
-    desc += `#**${userPosition}** - YOU - **${currency(userStreak)}**`
-    lbEmbed.setDescription(desc)
-    desc = ''
-
-    return msg.channel.send(lbEmbed.setTimestamp(new Date()))
-}
 
 const handleHelpLb = msg => {
     const lbHelpEmbed = new MessageEmbed()
@@ -160,16 +30,60 @@ const handleHelpLb = msg => {
     return msg.channel.send(lbHelpEmbed.setTimestamp(new Date()))
 }
 
-export default async (msg, client, args) => {
-    const users: any = await User.find({ banned: false })
-    if (!users) log('error', `ERROR: DB could not find users:\n**${users}**`, client)
+const formatFlipLb = (msg, topTen) => {
+    topTen.forEach(({ coinflipBestStreak, name }, pos) => {
+        const coinflipAmount: number = (coinflipBestStreak) ? Math.round((100 * (3 ** (coinflipBestStreak - 2))) + ((coinflipBestStreak - 1) * 150)) : 0
+        const coinflipChance: number = (coinflipBestStreak) ? Math.round((100 / (2 ** coinflipBestStreak)) * 100) / 100 : 0
+        desc += `#**${pos + 1}** ${name} - **${coinflipBestStreak}** - $**${currency(coinflipAmount)}** - ${coinflipChance}%\n`
+    })
+}
 
-    switch (args[0]) {
-        case 'cash': return handleCashLb(msg, users)
-        case 'bet': return handleBetLb(msg, users)
-        case 'streak': return handleStreakLb(msg, users)
-        case 'coinflip': return handleFlipLb(msg, users)
-        case 'help': return handleHelpLb(msg)
-        default: return handleCashLb(msg, users)
+const formatBetLb = (msg, topTen) => {
+    topTen.forEach(({ highestBet, name }, pos) => {
+        const betAmount: string = currency(highestBet.amount)
+        const betChance: number = Math.round(highestBet.chance * 100) / 100
+        desc += `#**${pos + 1}** ${name} - $**${betAmount}** - ${betChance}%\n`
+    })
+}
+
+const formatCashLb = (msg, topTen) => {
+    topTen.forEach((user, pos: number) => {
+        desc += `#**${pos + 1}** ${user.name} - $**${currency(user.balance)}**\n`
+    })
+}
+
+const formatStreakLb = (msg, topTen) => {
+    topTen.forEach((user, pos) => {
+        desc += `#**${pos + 1}** ${user.name} - **${currency(user.dailyStreak)}**\n`
+    })
+}
+
+const handleLeaderboard = (msg, type) => {
+    let desc: string = ''
+    const lbEmbed = new MessageEmbed()
+        .setColor(colors.green)
+        .setAuthor('Leaderboard')
+        .setFooter(`LeCashBot v${version}`)
+    
+    const leaderboardInfo = Leaderboard.findOne({ version: 1 });
+    
+    switch (leaderboardInfo[type]) {
+        case 'streak': formatStreakLb(msg, leaderboardInfo[type])
+        case 'balance': formatCashLb(msg, leaderboardInfo[type])
+        case 'coinflip': formatFlipLb(msg, leaderboardInfo[type])
+        case 'bet': formatBetLb(msg, leaderboardInfo[type])
     }
+
+    lbEmbed.setDescription(desc)
+    desc = ''
+
+    return msg.channel.send(lbEmbed.setTimestamp(new Date()))
+}
+
+export default async (msg, client, args) => {
+    if (args[0] === 'help') {
+        return handleHelpLb(msg);
+    }
+
+    return handleLeaderboard(msg, args[0]);
 }

--- a/src/commands/leaderboard.ts
+++ b/src/commands/leaderboard.ts
@@ -31,7 +31,7 @@ const handleHelpLb = msg => {
 }
 
 const formatFlipLb = (msg, topTen) => {
-    topTen.forEach(({ coinflipBestStreak, name }, pos) => {
+    topTen.reverse().forEach(({ coinflipBestStreak, name }, pos) => {
         const coinflipAmount: number = (coinflipBestStreak) ? Math.round((100 * (3 ** (coinflipBestStreak - 2))) + ((coinflipBestStreak - 1) * 150)) : 0
         const coinflipChance: number = (coinflipBestStreak) ? Math.round((100 / (2 ** coinflipBestStreak)) * 100) / 100 : 0
         desc += `#**${pos + 1}** ${name} - **${coinflipBestStreak}** - $**${currency(coinflipAmount)}** - ${coinflipChance}%\n`
@@ -39,7 +39,7 @@ const formatFlipLb = (msg, topTen) => {
 }
 
 const formatBetLb = (msg, topTen) => {
-    topTen.forEach(({ highestBet, name }, pos) => {
+    topTen.reverse().forEach(({ highestBet, name }, pos) => {
         const betAmount: string = currency(highestBet.amount)
         const betChance: number = Math.round(highestBet.chance * 100) / 100
         desc += `#**${pos + 1}** ${name} - $**${betAmount}** - ${betChance}%\n`
@@ -47,31 +47,38 @@ const formatBetLb = (msg, topTen) => {
 }
 
 const formatCashLb = (msg, topTen) => {
-    topTen.forEach((user, pos: number) => {
+    topTen.reverse().forEach((user, pos: number) => {
         desc += `#**${pos + 1}** ${user.name} - $**${currency(user.balance)}**\n`
     })
 }
 
 const formatStreakLb = (msg, topTen) => {
-    topTen.forEach((user, pos) => {
+    topTen.reverse().forEach((user, pos) => {
         desc += `#**${pos + 1}** ${user.name} - **${currency(user.dailyStreak)}**\n`
     })
 }
 
-const handleLeaderboard = (msg, type) => {
-    let desc: string = ''
+const handleLeaderboard = async (msg, type='balance') => {
     const lbEmbed = new MessageEmbed()
         .setColor(colors.green)
         .setAuthor('Leaderboard')
         .setFooter(`LeCashBot v${version}`)
     
-    const leaderboardInfo = Leaderboard.findOne({ version: 1 });
+    const leaderboardInfo = await Leaderboard.findOne({ version: 1 });
     
-    switch (leaderboardInfo[type]) {
-        case 'streak': formatStreakLb(msg, leaderboardInfo[type])
-        case 'balance': formatCashLb(msg, leaderboardInfo[type])
-        case 'coinflip': formatFlipLb(msg, leaderboardInfo[type])
-        case 'bet': formatBetLb(msg, leaderboardInfo[type])
+    switch (type) {
+        case 'streak': 
+            formatStreakLb(msg, leaderboardInfo[type])
+            break;
+        case 'balance': 
+            formatCashLb(msg, leaderboardInfo[type])
+            break;
+        case 'coinflip': 
+            formatFlipLb(msg, leaderboardInfo[type])
+            break;
+        case 'bet': 
+            formatBetLb(msg, leaderboardInfo[type])
+            break;
     }
 
     lbEmbed.setDescription(desc)
@@ -85,5 +92,5 @@ export default async (msg, client, args) => {
         return handleHelpLb(msg);
     }
 
-    return handleLeaderboard(msg, args[0]);
+    return await handleLeaderboard(msg, args[0]);
 }

--- a/src/events/ready.ts
+++ b/src/events/ready.ts
@@ -2,13 +2,15 @@ import { msgCooldown } from '../config/cooldowns'
 
 module.exports = async client => {
     const {
-        /*resetDailyStreak, */users,
+        resetDailyStreak, users,
         refreshActivity, logger,
-        msgCooldowns, guilds, user
+        msgCooldowns, guilds, user,
+        updateLeaderboards
     } = client
     const readyMsg: string = `${user.username} is ready: ${users.cache.size} users, ${guilds.cache.size} servers.`
 
-    //resetDailyStreak()
+    resetDailyStreak()
+    updateLeaderboards()
     refreshActivity()
     setInterval(() => msgCooldowns.splice(0, msgCooldowns.length), msgCooldown)
     logger.ready(readyMsg)

--- a/src/models/leaderboard.model.ts
+++ b/src/models/leaderboard.model.ts
@@ -1,0 +1,33 @@
+import * as mongoose from 'mongoose'
+
+const leaderboardtSchema = new mongoose.Schema({
+    version {
+        type: Number,
+        required: true,
+        default: 1
+    },
+    streak: {
+        type: Array,
+        required: false,
+        default: []
+    },
+    balance: {
+        type: Array,
+        required: false,
+        default: []
+    },
+    coinflip: {
+        type: Array,
+        required: false,
+        default: []
+    },
+    bet: {
+        type: Array,
+        required: false,
+        default: []
+    }
+})
+
+const Leaderboard = mongoose.model('Tournament', leaderboardSchema)
+
+export { Leaderboard }

--- a/src/models/leaderboard.model.ts
+++ b/src/models/leaderboard.model.ts
@@ -1,7 +1,7 @@
 import * as mongoose from 'mongoose'
 
-const leaderboardtSchema = new mongoose.Schema({
-    version {
+const leaderboardSchema = new mongoose.Schema({
+    version: {
         type: Number,
         required: true,
         default: 1
@@ -28,6 +28,6 @@ const leaderboardtSchema = new mongoose.Schema({
     }
 })
 
-const Leaderboard = mongoose.model('Tournament', leaderboardSchema)
+const Leaderboard = mongoose.model('Leaderboard', leaderboardSchema)
 
 export { Leaderboard }

--- a/src/modules/functions.ts
+++ b/src/modules/functions.ts
@@ -2,17 +2,18 @@ import { User } from '../models/user.model'
 import { log } from '../utils/log'
 import { toHours } from '../utils/date'
 import { Leaderboard } from '../models/leaderboard.model'
+import leaderboard from '../commands/leaderboard'
 
 const functions = (client: any) => {
     setInterval(client.refreshActivity = () => {
         client.logger.log('Updating presence...', 'log')
-        /*client.user.setPresence({ 
+        client.user.setPresence({ 
             activity: {
                 type: 'WATCHING', 
                 name: `${client.guilds.cache.size} servers.`
             }, 
             status: 'online'
-        })*/
+        })
         client.logger.log('Done updating presence.', 'ready')
     }, 5 * 60 * 1000)
 
@@ -37,21 +38,38 @@ const functions = (client: any) => {
     }, 5 * 60 * 1000)
 
     setInterval(client.updateLeaderboards = async () => {
+        client.logger.log('Updating leaderboards...')
+        
         const users: any = await User.find({ banned: false })
+        let lbTypes = ['streak', 'balance', 'coinflip', 'bet']
+        let leaderboardExists = await Leaderboard.findOne({ version: 1 })
+        
+        if (!leaderboardExists) {
+            return await createLeaderboard(client)
+        }
 
-        ['streak', 'balance', 'coinflip', 'bet'].forEach(leaderboardType => {
-            let newLeaderboard = sortLeaderboard(users, type)
+        await lbTypes.forEach(async leaderboardType => {
+            client.logger.log(`Updating ${leaderboardType} leaderboard.`);
+            let newLeaderboard = getTopTen(sortLeaderboard(users, leaderboardType))
             
-            await Leaderboard.updateOne({ __v: 0 }, {
+            await Leaderboard.updateOne({ version: 1 }, {
                 [leaderboardType]: newLeaderboard
+            }, async err => {
+                if (!err) client.logger.ready(`Updated ${leaderboardType} leaderboard.`)
+                
             })
-
-            log('ready', `Updated ${leaderboardType} leaderboard.`);
         })
     }, 5 * 60 * 1000)
 }
 
-const sortLeaderboard = type => {
+const createLeaderboard = async client => {
+    const leaderboard = new Leaderboard({ version: 1 });
+    client.logger.ready('Created leaderboard.')
+
+    return await leaderboard.save()
+}
+
+const sortLeaderboard = (users, type) => {
     const sortedUsers: any = sortUsers(users, type)
     const topTen: any = getTopTen(sortedUsers)
 
@@ -62,6 +80,8 @@ const getTopTen = (arr: any[]) => arr.slice(-10).reverse()
 
 // The sort type is the property of users that the function sorts by
 const sortUsers = (users: any[], sortType: string) => {
+    if (sortType === 'streak') sortType = 'dailyStreak'
+    
     if (sortType === 'bet') {
         return users.sort((a, b) => {
             const aBet: number = a.highestBet.amount
@@ -75,7 +95,7 @@ const sortUsers = (users: any[], sortType: string) => {
             const aStreak: number = a.coinflipBestStreak
             const bStreak: number = b.coinflipBestStreak
             return (aStreak > bStreak) ? 1 : ((bStreak > aStreak) ? -1 : 0)
-        }).reverse()
+        })
     }
 
     return users.sort((a, b) => {


### PR DESCRIPTION
## Description
Every time the `$leaderboard <type>` command was run, the bot would sort the leaderboard. This has now been fixed and sorts the leaderboard every 5 minutes and stores the information in the database. Whenever the `$leaderboard <type>` command is called, the information is simply retrieved from the database.

## Motivation and Context
To improve the performance of the `$leaderboard <type>` command. (#36)

## How Has This Been Tested?
[LeTestBot](https://discord.gg/UspVEng)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)