### PR TITLE
Fixed register command

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,14 +18,13 @@
   "dependencies": {
     "@babel/cli": "^7.14.5",
     "@babel/core": "^7.14.6",
-    "axios": "^0.21.1",
     "chalk": "^4.0.0",
     "discord.js": "^12.4.1",
     "dotenv": "^10.0.0",
     "format-duration": "^1.3.1",
+    "fsevents": "^2.3.2",
     "moment": "^2.24.0",
-    "mongoose": "^5.13.2",
-    "node-fetch": "^2.6.0"
+    "mongoose": "^5.13.2"
   },
   "devDependencies": {
     "@babel/node": "^7.14.7",

--- a/src/commands/register.js
+++ b/src/commands/register.js
@@ -1,9 +1,9 @@
 import { User } from '../models/user.model';
-const fetch = require(`node-fetch`);
+const cloudscraper = require(`cloudscraper`);
 
-const urlExists = async url => await fetch(url)
-    .then((res) => res.text())
-    .then((res) => res.includes(`RACER_INFO`));
+const urlExists = async url => await cloudscraper.get(url)
+    .then((res) => res.includes(`RACER_INFO`))
+    .catch((err) => false); // apparently it returns a captcha error if the racer doens't exist
 
 const registerUser = (msg, ntLink) => {
     const user = new User({

--- a/yarn.lock
+++ b/yarn.lock
@@ -4253,7 +4253,7 @@ node-environment-flags@^1.0.5:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
 
-node-fetch@^2.6.0, node-fetch@^2.6.1:
+node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
Was going to use [axios](https://www.npmjs.com/package/axios), but ended up using [cloudscraper](https://www.npmjs.com/package/cloudscraper) since axios was unreliable.

**Was not tested with the full bot** - i was clearly incapable of fixing mongoDB today, but the code changed code in the register command was tested in a different place and seems to work